### PR TITLE
Adding ability to set minimum supported app version by platform

### DIFF
--- a/app/css/forms.scss
+++ b/app/css/forms.scss
@@ -32,7 +32,7 @@
     @include link;
 }
 .help-text {
-    color: #ccc;
-    letter-spacing: 1px;
+    color: #aaa;
+    font-style: italic;
     padding: 0 .5rem;
 }

--- a/app/src/pages/info/info.html
+++ b/app/src/pages/info/info.html
@@ -36,7 +36,7 @@
                 </div>
                 <div class="field">
                     <label>Minimum Supported App Versions</label>
-                    <p style="font-style:italic; color: #aaa">Leave blank or set to zero if you support all versions that have been released</p>
+                    <p class="help-text">Leave blank or set to zero if you support all versions that have been released</p>
                     <div class="six fields">
                         <div class="field">
                             <label>iOS</label>

--- a/app/src/pages/info/info.html
+++ b/app/src/pages/info/info.html
@@ -35,6 +35,20 @@
                     </ui-checkbox>
                 </div>
                 <div class="field">
+                    <label>Minimum Supported App Versions</label>
+                    <p style="font-style:italic; color: #aaa">Leave blank or set to zero if you support all versions that have been released</p>
+                    <div class="six fields">
+                        <div class="field">
+                            <label>iOS</label>
+                            <input placeholder="#" type="number" data-bind="value: minIosObs"/>
+                        </div>
+                        <div class="field">
+                            <label>Android</label>
+                            <input placeholder="#" type="number" data-bind="value: minAndroidObs"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="field">
                     <button class="ui small button" data-bind="click: publicKey">Download CMS Public Key</button>
                 </div>
             </form>
@@ -47,6 +61,11 @@
                 <p>Please do not disable strict upload validation unless instructed to do so. If your
                     application submits corrupted data, you will have to fix it after the data
                     is collected. </p>
+
+                <p>If your study no longer supports an older app version on a particular platform, lock that version
+                    out by setting a <b>minimum supported app version</b>. Apps older than this version on that
+                    platform will receive a 410 response from the server. Your app should prevent the user from
+                    doing anything but upgrading when it receives this response. </p>
 
                 <p>The CMS key is provided to encrypt data you send to the Bridge server. The encryption key
                     (specific to your study) ensures that the data cannot be read on the phone, or in transit to

--- a/app/src/pages/info/info.js
+++ b/app/src/pages/info/info.js
@@ -6,7 +6,20 @@ var utils = require('../../utils');
 // var root = require('../../root');
 
 var fields = ['message', 'name', 'sponsorName', 'technicalEmail', 'supportEmail',
-    'consentNotificationEmail', 'identifier', 'strictUploadValidationEnabled'];
+    'consentNotificationEmail', 'identifier', 'strictUploadValidationEnabled', 'minIos', 'minAndroid'];
+
+function updateMinAppVersion(vm, obs, name) {
+    var value = parseInt(obs(),10);
+    if (value >= 0) {
+        vm.study.minSupportedAppVersions[name] = value;
+    }
+    obs(value);
+}
+function updateMinAppObservers(study, obs, name) {
+    if (study.minSupportedAppVersions[name]) {
+        obs(study.minSupportedAppVersions[name]);
+    }
+}
 
 module.exports = function() {
     var self = this;
@@ -17,6 +30,10 @@ module.exports = function() {
     self.save = function(vm, event) {
         utils.startHandler(self, event);
         utils.observablesToObject(self, self.study, fields);
+
+        self.study.minSupportedAppVersions = {};
+        updateMinAppVersion(self, self.minIosObs, "iPhone OS");
+        updateMinAppVersion(self, self.minAndroidObs, "Android");
 
         serverService.saveStudy(self.study)
             .then(function(response) {
@@ -35,5 +52,7 @@ module.exports = function() {
     serverService.getStudy().then(function(study) {
         self.study = study;
         utils.valuesToObservables(self, study, fields);
+        updateMinAppObservers(study, self.minIosObs, 'iPhone OS');
+        updateMinAppObservers(study, self.minAndroidObs, 'Android');
     });
 };


### PR DESCRIPTION
Set a minimum integer value for the version of an app on iOS or Android, and apps under that version will get a 410 back when trying to retrieve a session on any request that requires the user to be consented (almost all user APIs).
