### PR TITLE
Copy schema dialog; study-specific config

### DIFF
--- a/app/src/components.js
+++ b/app/src/components.js
@@ -77,6 +77,7 @@ reg('date_window_editor', './dialogs/date_window_editor/date_window_editor');
 reg('external_id_importer', './dialogs/external_id_importer/external_id_importer');
 reg('participant_export', './dialogs/participant_export/participant_export');
 reg('new_external_id', './dialogs/new_external_id/new_external_id');
+reg('copy_schemas', './dialogs/copy_schemas/copy_schemas');
 
 /* SURVEYS */
 regt('SurveyInfoScreen', './pages/survey/survey_info');

--- a/app/src/config.js
+++ b/app/src/config.js
@@ -18,6 +18,11 @@ module.exports = {
         preventDuplicates: true,
         opacity: 1.0
     },
+    studies: {
+        'parkinson-lux': {
+            showExternalIds: true
+        }
+    },
     signIn: '/v3/auth/signIn',
     signOut: '/v3/auth/signOut',
     getStudy: '/v3/studies/',

--- a/app/src/dialogs/copy_schemas/copy_schemas.html
+++ b/app/src/dialogs/copy_schemas/copy_schemas.html
@@ -1,0 +1,33 @@
+<div class="ui small modal">
+    <i class="close icon"></i>
+    <div class="header">
+        Copy upload schemas
+    </div>
+    <div class="content">
+        <p>To copy this schema, choose a new ID for your copy. You can also change the name if you wish. </p>
+        <form class="ui form">
+            <div class="fields">
+                <div class="twelve wide field required">
+                    <label>Schema ID</label>
+                    <input type="text" data-bind="textInput: schemaIdObs"/>
+                </div>
+                <div class="four wide field">
+                    <label>Schema revision</label>
+                    <input type="text" data-bind="textInput: revisionObs, semantic: 'popup'"
+                        data-content="You can force the creation of this schema at an arbitrary revision number. You can ignore this unless you are trying fix a released app pointing at a specific revision number."
+                    />
+                </div>
+            </div>
+            <div class="field">
+                <label>New schema name</label>
+                <input type="text" data-bind="textInput: nameObs"/>
+            </div>
+        </fom>
+    </div>
+    <div class="actions">
+        <button class="ui small button" data-bind="disable: !canGoPreviousObs(), click: previous">Previous</button>
+        <button class="ui small button" data-bind="disable: !canGoNextObs(), click: next">Next</button>
+        <button class="ui primary small button" data-bind="disable: !canCopyObs(), click: copy">Copy</button>
+        <button class="ui small button" data-bind="click: closeDialog">Cancel</button>
+    </div>
+</div>

--- a/app/src/dialogs/copy_schemas/copy_schemas.js
+++ b/app/src/dialogs/copy_schemas/copy_schemas.js
@@ -1,0 +1,89 @@
+var serverService = require('../../services/server_service');
+var ko = require('knockout');
+var root = require('../../root');
+var utils = require('../../utils');
+var Promise = require('bluebird');
+
+module.exports = function(params) {
+    var self = this;
+
+    var copyables = params.copyables;
+    var specs = [];
+    var allUpdated = false;
+
+    self.indexObs = ko.observable(0);
+    self.nameObs = ko.observable(copyables[0].name + " (Copy)");
+    self.schemaIdObs = ko.observable(copyables[0].schemaId);
+    self.revisionObs = ko.observable(1);
+
+    function updateObserversFromCopyables() {
+        var index = self.indexObs();
+        var name = /\(Copy\)$/.test(copyables[index].name) ?
+            copyables[index].name :
+            copyables[index].name + " (Copy)";
+        self.nameObs(name);
+        self.schemaIdObs(copyables[index].schemaId);
+        self.revisionObs(1);
+    }
+    function updateSpecsFromObservers() {
+        var index = self.indexObs();
+        specs[index] = Object.assign({}, copyables[index], {
+            name: self.nameObs(),
+            schemaId: self.schemaIdObs(),
+            revision: self.revisionObs()
+        });
+    }
+    function updateObserversFromSpecs() {
+        var index = self.indexObs();
+        self.nameObs(specs[index].name);
+        self.schemaIdObs(specs[index].schemaId);
+        self.revisionObs(specs[index].revision);
+    }
+    function validValues() {
+        return self.schemaIdObs() !== "" && parseInt(self.revisionObs()) > 0;
+    }
+    function changedValues() {
+        var index = self.indexObs();
+        return (self.schemaIdObs() != copyables[index].schemaId) || (self.revisionObs() != 1);
+    }
+
+    self.canGoPreviousObs = ko.computed(function() {
+        return self.indexObs() > 0;
+    });
+    self.canGoNextObs = ko.computed(function() {
+        return validValues() && changedValues() && self.indexObs() < (copyables.length-1);
+    });
+    self.canCopyObs = ko.computed(function() {
+        return validValues() && changedValues() && self.indexObs() === (copyables.length-1);
+    });
+
+    self.previous = function() {
+        updateSpecsFromObservers();
+        self.indexObs(self.indexObs()-1);
+        updateObserversFromSpecs();
+    };
+    self.next = function() {
+        updateSpecsFromObservers();
+        self.indexObs(self.indexObs()+1);
+        if (specs[self.indexObs()]) {
+            updateObserversFromSpecs();
+        } else {
+            updateObserversFromCopyables();
+        }
+    };
+    self.copy = function(vm, event) {
+        updateSpecsFromObservers();
+        utils.startHandler(vm, event);
+
+        Promise.map(specs, function(schema) {
+            return serverService.createUploadSchema(schema);
+        }).then(function() {
+            params.closeCopySchemasDialog();
+        })
+        .then(utils.successHandler(vm, event))
+        .catch(utils.failureHandler(vm, event));
+    };
+    self.closeDialog = function() {
+        root.closeDialog();
+    };
+};

--- a/app/src/pages/schema/schema.html
+++ b/app/src/pages/schema/schema.html
@@ -56,16 +56,9 @@
                 <label>Schema Type</label>
                 <ui-select params="fieldObs: schemaTypeObs, fieldLabel: schemaTypeLabel, optionsSrc: schemaTypeOptions"></ui-select>
             </div>
-            <div class="two fields" data-bind="visible: isNewObs">
-                <div class="required field" id="schemaId">
-                    <label>Identifier</label>
-                    <input type="text" data-bind="textInput: schemaIdObs"/>
-                </div>
-                <div class="field">
-                    <label>Revision</label>
-                    <input type="text" data-bind="textInput: revisionObs, semantic: 'popup'"
-                        data-content="Leave this blank and we&rsquo;ll save it as &quot;revision 1.&quot; Which is what you want. But if you&rsquo;re some kind of Bridge server wizard, you can pick another revision to use, usually to fix a past mistake."/>
-                </div>
+            <div class="required field" id="schemaId" data-bind="visible: isNewObs">
+                <label>Identifier</label>
+                <input type="text" data-bind="textInput: schemaIdObs"/>
             </div>
             <div class="field" data-bind="visible: !isNewObs()">
                 <label>Identifier</label>

--- a/app/src/pages/schemas/schemas.html
+++ b/app/src/pages/schemas/schemas.html
@@ -4,6 +4,8 @@
             <h3>Data Schemas</h3>
         </div>
         <div class="fixed-header-buttons">
+            <button class="ui small button" data-bind="disable: !atLeastOneChecked(), click: copySchemasDialog">Copy</button>
+            <button class="ui red small button" data-bind="disable: !atLeastOneChecked(), click: deleteSchemas">Delete</button>
             <a href="#/schemas/new" class="ui primary small button">New Schema</a>
         </div>
     </div>
@@ -15,6 +17,7 @@
     <table class="ui compact selectable table" data-bind="visible: itemsObs().length > 0">
         <thead>
             <tr>
+                <th width="10"></th>
                 <th>Name</th>
                 <th>Type</th>
                 <th>Latest Revision</th>
@@ -22,6 +25,9 @@
         </thead>
         <tbody data-bind="foreach: itemsObs">
             <tr data-bind="css: { positive: $data.active }">
+                <td>
+                    <ui-checkbox params="checkedObs: $data.checkedObs"></ui-checkbox>
+                </td>
                 <td>
                     <a data-bind="attr: {'href': '#/schemas/'+encodeURIComponent($data.schemaId)}, text: $data.name"></a>
                 </td>

--- a/app/src/pages/schemas/schemas.js
+++ b/app/src/pages/schemas/schemas.js
@@ -2,6 +2,8 @@ var ko = require('knockout');
 var serverService = require('../../services/server_service');
 var schemaUtils = require('../schema/schema_utils');
 var utils = require('../../utils');
+var root = require('../../root');
+var Promise = require('bluebird');
 
 module.exports = function() {
     var self = this;
@@ -9,14 +11,50 @@ module.exports = function() {
     schemaUtils.initSchemasVM(self);
     self.itemsObs = ko.observableArray([]);
 
-    serverService.getAllUploadSchemas().then(function(response) {
-        var items = response.items
-                //.filter(filterIosDataItems) there are actually people using the hand-crafted survey schemas
-                .sort(utils.makeFieldSorter("name"));
-        if (items.length) {
-            self.itemsObs(items);
-        } else {
-            document.querySelector(".loading_status").textContent = "There are currently no upload schemas.";
+    function closeCopySchemasDialog() {
+        root.closeDialog();
+        root.message('success', 'Schemas copied');
+        load();
+    }
+
+    self.atLeastOneChecked = function () {
+        return self.itemsObs().some(function(item) {
+            return item.checkedObs();
+        });
+    };
+    self.copySchemasDialog = function(vm, event) {
+        var copyables = self.itemsObs().filter(utils.hasBeenChecked);
+        root.openDialog('copy_schemas', {copyables: copyables, closeCopySchemasDialog: closeCopySchemasDialog});
+    };
+    self.deleteSchemas = function(vm, event) {
+        var deletables = self.itemsObs().filter(utils.hasBeenChecked);
+        var msg = (deletables.length > 1) ?
+                "You will delete ALL revisions of these upload schemas.\n\nAre you sure you want to delete these schemas?" :
+                "You will delete ALL revisions of this upload schema.\n\nAre you sure you want to delete this schema?";
+        var confirmMsg = (deletables.length > 1) ?
+                "All revisions of these schemas have been deleted." : "All revisions of this schema have been deleted.";
+
+        if (confirm(msg)) {
+            utils.startHandler(self, event);
+            Promise.map(deletables, function(schema) {
+                return serverService.deleteSchema(schema.schemaId);
+            }).then(utils.makeTableRowHandler(vm, deletables, "#/schemas"))
+                .then(utils.successHandler(vm, event, confirmMsg))
+                .catch(utils.failureHandler(vm, event));
         }
-    });
+    };
+
+    function load() {
+        serverService.getAllUploadSchemas().then(function(response) {
+            var items = response.items
+                .sort(utils.makeFieldSorter("name"))
+                .map(utils.addCheckedObs);
+            if (items.length) {
+                self.itemsObs(items);
+            } else {
+                document.querySelector(".loading_status").textContent = "There are currently no upload schemas.";
+            }
+        });
+    }
+    load();
 };

--- a/app/src/root.js
+++ b/app/src/root.js
@@ -112,15 +112,20 @@ var RootViewModel = function() {
         self.rolesObs(session.roles);
         self.closeDialog();
         serverService.getStudy().then(function(study) {
-            // show Participants if emailVerificationEnabled.
-            self.showParticipantsObs(study.emailVerificationEnabled && self.isResearcher());
-            // otherwise show Lab Codes. Note roles are different. 
-            self.showLabCodesObs(!study.emailVerificationEnabled && self.isDeveloper());
-            // Show external IDs if emailVerificationEnabled and externalIdValidationEnabled. Or if you are mPower lux...
-            // which is using the creation of credentials to track usage of codes, which is GOOD, I thought no one
-            // was doing that.
-            self.showExternalIdsObs(study.identifier === "parkinson-lux" || 
-                (study.emailVerificationEnabled && study.externalIdValidationEnabled && self.isDeveloper()));
+            // sensible defaults.
+            var defaults = {
+                showParticipants: study.emailVerificationEnabled && self.isResearcher(),
+                showLabCodes: !study.emailVerificationEnabled && self.isDeveloper(),
+                showExternalIds: study.emailVerificationEnabled && study.externalIdValidationEnabled && self.isDeveloper()
+            };
+            // study-specific overrides, currently located in config.
+            var studyConfig = config.studies[study.identifier] || {};
+            var opts = Object.assign({}, defaults, studyConfig);
+            console.log("UI configuration", opts);
+
+            self.showParticipantsObs(opts.showParticipants);
+            self.showLabCodesObs(opts.showLabCodes);
+            self.showExternalIdsObs(opts.showExternalIds);
         });
     });
     serverService.addSessionEndListener(function(session) {

--- a/app/src/services/server_service.js
+++ b/app/src/services/server_service.js
@@ -314,6 +314,9 @@ module.exports = {
             return response;
         });
     },
+    deleteSchema: function(schemaId) {
+        return del(config.schemas + "/" + schemaId);
+    },
     deleteSchemaRevision: function(schema) {
         return del(config.schemas + "/" + schema.schemaId + "/revisions/" + schema.revision);
     },


### PR DESCRIPTION
Add a dialog to copy schemas, create schemas with an arbitrary revision number.

Config now contains study-specific overrides for what combination of participants, external IDs and lab codes to show for a given study. Defaults are as discussed via email, if nothing else is set.
