### PR TITLE
Adding ability to set ranges for iOS or Android.

### DIFF
--- a/app/css/forms.scss
+++ b/app/css/forms.scss
@@ -71,6 +71,7 @@ label[for] {
     border-radius: .28571429rem;
     box-shadow: 0 0 0 0 transparent inset;
     display: inline-block!important;
+    text-align:center!important;
 }
 .range-control-border input, .range-control-border input:focus {
     text-align:center!important;
@@ -79,4 +80,7 @@ label[for] {
     display: inline-block!important;
     width:3rem!important;
     padding: .2rem!important;
+}
+.range-control-border-active {
+    border-color:#85B7D9!important;
 }

--- a/app/css/forms.scss
+++ b/app/css/forms.scss
@@ -56,3 +56,27 @@ input[readonly] {
 label[for] {
     cursor: pointer!important;
 }
+
+/* For creating range controls in criteria editor. */
+.range-control-border {
+    font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;
+    margin: 0;
+    outline: 0;
+    -webkit-appearance: none;
+    padding: .47rem .2rem!important;
+    font-size: 1em;
+    background: #FFF;
+    border: 1px solid rgba(34,36,38,.15);
+    color: rgba(0,0,0,.87);
+    border-radius: .28571429rem;
+    box-shadow: 0 0 0 0 transparent inset;
+    display: inline-block!important;
+}
+.range-control-border input, .range-control-border input:focus {
+    text-align:center!important;
+    border: none!important;
+    box-shadow: none!important;
+    display: inline-block!important;
+    width:3rem!important;
+    padding: .2rem!important;
+}

--- a/app/src/bindings.js
+++ b/app/src/bindings.js
@@ -24,6 +24,15 @@ ko.observableArray.fn.contains = function(value) {
     return underlyingArray.indexOf(value) > -1;
 };
 
+ko.bindingHandlers.focusable = {
+    init: function(element) {
+        $(element).find('input').on('focus', function() {
+            element.classList.add("range-control-border-active");
+        }).on('blur', function() {
+            element.classList.remove("range-control-border-active");
+        });
+    }
+};
 ko.bindingHandlers.flatpickr = {
     init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
         var observer = valueAccessor();

--- a/app/src/criteria_utils.js
+++ b/app/src/criteria_utils.js
@@ -12,20 +12,40 @@ function valueForObs(criteria, field) {
     }
     return criteria[field];
 }
+function formatVersionRange(minAppVersion, maxAppVersion) {
+    if (utils.isNotBlank(minAppVersion) && utils.isNotBlank(maxAppVersion)) {
+        return "v" + minAppVersion + "-" + maxAppVersion;
+    } else if (utils.isNotBlank(minAppVersion)) {
+        return "v" + minAppVersion + "+";
+    } else if (utils.isNotBlank(maxAppVersion)) {
+        return "v" + "0-" + maxAppVersion;
+    }
+    return null;
+}
 function label(criteria) {
-    var minAppVersion = valueForObs(criteria, "minAppVersion");
-    var maxAppVersion = valueForObs(criteria, "maxAppVersion");
+    // These properties don't necessarily exist, which throws reference errors. So init them.
+    criteria.minAppVersions = criteria.minAppVersions || {};
+    criteria.maxAppVersions = criteria.maxAppVersions || {};
+    var iosMin = valueForObs(criteria.minAppVersions, "iphone_os");
+    var iosMax = valueForObs(criteria.maxAppVersions, "iphone_os");
+    var androidMin = valueForObs(criteria.minAppVersions, "android");
+    var androidMax = valueForObs(criteria.maxAppVersions, "android");
     var language = valueForObs(criteria, "language");
     var allOfGroups = valueForObs(criteria, "allOfGroups");
     var noneOfGroups = valueForObs(criteria, "noneOfGroups");
+    var iosRange = formatVersionRange(iosMin, iosMax);
+    var androidRange = formatVersionRange(androidMin, androidMax);
 
     var arr = [];
-    if (utils.isNotBlank(minAppVersion) && utils.isNotBlank(maxAppVersion)) {
-        arr.push("v" + minAppVersion + "-" + maxAppVersion);
-    } else if (utils.isNotBlank(minAppVersion)) {
-        arr.push("v" + minAppVersion + "+");
-    } else if (utils.isNotBlank(maxAppVersion)) {
-        arr.push("v" + "0-" + maxAppVersion);
+    if (iosRange !== null && iosRange === androidRange) {
+        arr.push(iosRange);
+    } else {
+        if (iosRange !== null) {
+            arr.push(iosRange + " (on iOS)");
+        }
+        if (androidRange !== null) {
+            arr.push(androidRange + " (on Android)");
+        }
     }
     if (utils.isNotBlank(language)) {
         arr.push("'" + language + "' language");

--- a/app/src/widgets/criteria/criteria.html
+++ b/app/src/widgets/criteria/criteria.html
@@ -2,7 +2,7 @@
     <!-- Doesn't handle errors targeted for minAppVersions_iphone_os -->
     <div data-bind="attr:{class:'three wide field '+$data.id+'minAppVersions_iphone_os ' + $data.id+'maxAppVersions_iphone_os'}">
         <label>Version (on iOS):</label>
-        <div class="field range-control-border">
+        <div class="field range-control-border" data-bind="focusable">
             <input type="text" placeholder="Min" data-bind="textInput: $data.iosMinObs"/>
             <span>&mdash;</span>
             <input type="text" placeholder="Max" data-bind="textInput: $data.iosMaxObs"/>
@@ -10,7 +10,7 @@
     </div>
     <div data-bind="attr:{class:'three wide field '+$data.id+'minAppVersions_android ' + $data.id+'maxAppVersions_android'}">
         <label>Version (on Android):</label>
-        <div class="field range-control-border">
+        <div class="field range-control-border" data-bind="focusable">
             <input type="text" placeholder="Min" data-bind="textInput: $data.androidMinObs"/>
             <span>&mdash;</span>
             <input type="text" placeholder="Max" data-bind="textInput: $data.androidMaxObs"/>

--- a/app/src/widgets/criteria/criteria.html
+++ b/app/src/widgets/criteria/criteria.html
@@ -1,12 +1,23 @@
 <div class="fields">
-    <div class="four wide field">
-        <label>App version:</label>
+    <div class="three wide field">
+        <label>App version (on iOS):</label>
         <div class="two fields">
             <div class="eight wide field" data-bind="attr:{id:$data.id+'minAppVersion'}">
-                <input type="number" data-bind="textInput: $data.minAppVersionObs" placeholder="Min"/>
+                <input type="number" data-bind="textInput: $data.iosMinObs" placeholder="Min"/>
             </div>
             <div class="eight wide field" data-bind="attr:{id:$data.id+'maxAppVersion'}">
-                <input type="number" data-bind="textInput: $data.maxAppVersionObs" placeholder="Max"/>
+                <input type="number" data-bind="textInput: $data.iosMaxObs" placeholder="Max"/>
+            </div>
+        </div>
+    </div>
+    <div class="three wide field">
+        <label>App version (on Android):</label>
+        <div class="two fields">
+            <div class="eight wide field" data-bind="attr:{id:$data.id+'minAppVersion'}">
+                <input type="number" data-bind="textInput: $data.androidMinObs" placeholder="Min"/>
+            </div>
+            <div class="eight wide field" data-bind="attr:{id:$data.id+'maxAppVersion'}">
+                <input type="number" data-bind="textInput: $data.androidMaxObs" placeholder="Max"/>
             </div>
         </div>
     </div>
@@ -14,7 +25,7 @@
         <label>Language</label>
         <input type="text" class="field" data-bind="textInput: $data.languageObs"/>
     </div>
-    <div class="six wide field tag-editor" data-bind="attr:{id: $data.id+'allOfGroups'}">
+    <div class="five wide field tag-editor" data-bind="attr:{id: $data.id+'allOfGroups'}">
         <label>User has all these data group(s):</label>
         <!-- ko component: {
             name: "tag-editor",
@@ -24,7 +35,7 @@
             }
         } --><!-- /ko -->
     </div>
-    <div class="six wide field tag-editor" data-bind="attr:{id: $data.id+'noneOfGroups'}">
+    <div class="five wide field tag-editor" data-bind="attr:{id: $data.id+'noneOfGroups'}">
         <label>And none of these group(s):</label>
         <!-- ko component: {
             name: "tag-editor",

--- a/app/src/widgets/criteria/criteria.html
+++ b/app/src/widgets/criteria/criteria.html
@@ -1,24 +1,19 @@
 <div class="fields">
-    <div class="three wide field">
-        <label>App version (on iOS):</label>
-        <div class="two fields">
-            <div class="eight wide field" data-bind="attr:{id:$data.id+'minAppVersion'}">
-                <input type="number" data-bind="textInput: $data.iosMinObs" placeholder="Min"/>
-            </div>
-            <div class="eight wide field" data-bind="attr:{id:$data.id+'maxAppVersion'}">
-                <input type="number" data-bind="textInput: $data.iosMaxObs" placeholder="Max"/>
-            </div>
+    <!-- Doesn't handle errors targeted for minAppVersions_iphone_os -->
+    <div data-bind="attr:{class:'three wide field '+$data.id+'minAppVersions_iphone_os ' + $data.id+'maxAppVersions_iphone_os'}">
+        <label>Version (on iOS):</label>
+        <div class="field range-control-border">
+            <input type="text" placeholder="Min" data-bind="textInput: $data.iosMinObs"/>
+            <span>&mdash;</span>
+            <input type="text" placeholder="Max" data-bind="textInput: $data.iosMaxObs"/>
         </div>
     </div>
-    <div class="three wide field">
-        <label>App version (on Android):</label>
-        <div class="two fields">
-            <div class="eight wide field" data-bind="attr:{id:$data.id+'minAppVersion'}">
-                <input type="number" data-bind="textInput: $data.androidMinObs" placeholder="Min"/>
-            </div>
-            <div class="eight wide field" data-bind="attr:{id:$data.id+'maxAppVersion'}">
-                <input type="number" data-bind="textInput: $data.androidMaxObs" placeholder="Max"/>
-            </div>
+    <div data-bind="attr:{class:'three wide field '+$data.id+'minAppVersions_android ' + $data.id+'maxAppVersions_android'}">
+        <label>Version (on Android):</label>
+        <div class="field range-control-border">
+            <input type="text" placeholder="Min" data-bind="textInput: $data.androidMinObs"/>
+            <span>&mdash;</span>
+            <input type="text" placeholder="Max" data-bind="textInput: $data.androidMaxObs"/>
         </div>
     </div>
     <div class="two wide field" data-bind="attr:{id:$data.id+'language'}">

--- a/app/src/widgets/errors/errors.js
+++ b/app/src/widgets/errors/errors.js
@@ -44,8 +44,15 @@ module.exports = function() {
         for (var fieldName in errors) {
             var string = errors[fieldName].map(truncateErrorFieldKey).join("; ");
 
+            // This now attempts to find a class token because the range controls have one field
+            // border and two controls, both of which can have server errors. Were I to redo this, 
+            // I might be inclined to switch over entirely to class tokens rather than IDs to 
+            // simplify this, but it introduces new difficulties.
             var id = errorFieldKeyToId(fieldName);
             var fieldEl = document.getElementById(id);
+            if (!fieldEl) {
+                fieldEl = document.querySelector("."+id);
+            }
             if (fieldEl) {
                 var div = document.createElement("div");
                 div.className = "ui basic red pointing prompt label transition visible";

--- a/test/range-control.html
+++ b/test/range-control.html
@@ -20,6 +20,9 @@
     border-radius: .28571429rem;
     box-shadow: 0 0 0 0 transparent inset;
 }
+.synthetic-control-border:focus {
+    outline: 1px solid red;
+}
 .synthetic-control-border input, .synthetic-control-border input:focus {
     border: none!important;
     box-shadow: none!important;
@@ -30,7 +33,7 @@
 </style>
 <body style="padding: 3rem">
     <form class="ui form">
-        <div class="synthetic-control-border">
+        <div class="synthetic-control-border" tabindex="0">
             <input style="text-align:right" type="text" placeholder="Min"/><span>&mdash;</span><input type="text" placeholder="Max"/>
         </div>
     </form>

--- a/test/range-control.html
+++ b/test/range-control.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Bridge Study Manager</title>
+    <!--Not clear if this is doing anything, but what the heck-->
+    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2/semantic.min.css"/>
+</head>
+<style>
+.synthetic-control-border {
+    font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;
+    margin: 0;
+    outline: 0;
+    -webkit-appearance: none;
+    padding: .67861429em 1em;
+    font-size: 1em;
+    background: #FFF;
+    border: 1px solid rgba(34,36,38,.15);
+    color: rgba(0,0,0,.87);
+    border-radius: .28571429rem;
+    box-shadow: 0 0 0 0 transparent inset;
+}
+.synthetic-control-border input, .synthetic-control-border input:focus {
+    border: none!important;
+    box-shadow: none!important;
+    display: inline!important;
+    width:3rem!important;
+    padding: .2rem .4rem!important;
+}
+</style>
+<body style="padding: 3rem">
+    <form class="ui form">
+        <div class="synthetic-control-border">
+            <input style="text-align:right" type="text" placeholder="Min"/><span>&mdash;</span><input type="text" placeholder="Max"/>
+        </div>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
Criteria component now accepts values for these two platforms, persists that correctly, and displays it correctly on subpopulations and schedules pages (and in the sidebar widget for the criteria schedule editor).
