### PR TITLE
Preserve a schedule when switching type.

### DIFF
--- a/app/src/bindings.js
+++ b/app/src/bindings.js
@@ -46,7 +46,9 @@ ko.bindingHandlers.flatpickr = {
         function createPicker() {
             var d = (observer()) ? new Date(observer()) : null;
             flatpickr(element, {defaultDate: d, onChange: updateObserver});
-            element.value = d[includeTime ? "toLocaleString" : "toLocaleDateString"]();
+            if (d) {
+                element.value = d[includeTime ? "toLocaleString" : "toLocaleDateString"]();
+            }
         }
         // You must delay initialization in a modal until after the modal is open, or 
         // the picker works... but spontaneously opens. Just add timeout: 600 to the 

--- a/app/src/criteria_utils.js
+++ b/app/src/criteria_utils.js
@@ -60,8 +60,8 @@ function label(criteria) {
 }
 function newCriteria() {
     return {
-        minAppVersion:null,
-        maxAppVersion:null,
+        minAppVersions:{},
+        maxAppVersions:{},
         language:null,
         allOfGroups:[],
         noneOfGroups:[]

--- a/app/src/pages/participant/general.js
+++ b/app/src/pages/participant/general.js
@@ -43,9 +43,11 @@ module.exports = function(params) {
         .obs('title', (userId === "new") ? "New participant" : "&#160;");
     
     self.isPublicObs = root.isPublicObs;
-    serverService.getParticipantName(userId).then(function(part) {
-        self.titleObs(root.isPublicObs() ? part.name : part.externalId);
-    }).catch(utils.failureHandler());
+    if (!self.isNewObs()) {
+        serverService.getParticipantName(userId).then(function(part) {
+            self.titleObs(root.isPublicObs() ? part.name : part.externalId);
+        }).catch(utils.failureHandler());
+    }
     
     self.statusObs.subscribe(function(status) {
         self.showEnableAccountObs(status !== "enabled");

--- a/app/src/pages/schedule/schedule.js
+++ b/app/src/pages/schedule/schedule.js
@@ -8,7 +8,8 @@ var alerts = require('../../widgets/alerts');
 
 var SCHEDULE_TYPE_OPTIONS = Object.freeze([
     {value: 'once', label: 'Once'},
-    {value: 'recurring', label: 'Recurring'}
+    {value: 'recurring', label: 'Recurring'},
+    {value: 'cron', label: 'Cron-based'}
 ]);
 var ACTIVITY_TYPE_OPTIONS = Object.freeze([
     {value: 'task', label: 'Do Task'},

--- a/app/src/pages/schedule/strategies/simple_strategy.js
+++ b/app/src/pages/schedule/strategies/simple_strategy.js
@@ -15,13 +15,17 @@ module.exports = function(params) {
         return strategy;
     };
 
-    // This is fired when the parent viewModel gets a plan back from the server
-    ko.computed(function () {
-        var strategy = params.strategyObs();
+    function initStrategy(strategy) {
         if (strategy && strategy.schedule) {
-            self.scheduleObs(strategy.schedule);
+            setTimeout(function() {
+                self.scheduleObs(strategy.schedule);
+            }, 1);
+            root.setEditorPanel('SimpleScheduleStrategyPanel', {viewModel:self});
         }
-    });
-
-    root.setEditorPanel('SimpleScheduleStrategyPanel', {viewModel:self});
+    }
+    initStrategy(params.strategyObs());
+    var subscription = params.strategyObs.subscribe(function(strategy) {
+        initStrategy(strategy);
+        subscription.dispose();
+    });    
 };

--- a/app/src/pages/scheduleplan/scheduleplan.js
+++ b/app/src/pages/scheduleplan/scheduleplan.js
@@ -19,21 +19,16 @@ module.exports = function(params) {
         .bind('label', '')
         .bind('minAppVersion', '')
         .bind('maxAppVersion', '')
-        .obs('schedulePlanType', 'SimpleScheduleStrategy');
+        .obs('schedulePlanType', (params.guid==="new") ? 'SimpleScheduleStrategy' : null);
         
     self.strategyObs.callback = utils.identity;
     // Fields for this form
     self.schedulePlanTypeOptions = scheduleUtils.TYPE_OPTIONS;
     self.schedulePlanTypeLabel = utils.makeOptionLabelFinder(scheduleUtils.TYPE_OPTIONS);
-    
-    self.schedulePlanTypeObs.subscribe(function(newValue) {
-        if (newValue === 'SimpleScheduleStrategy') {
-            self.strategyObs(scheduleUtils.newSimpleStrategy());
-        } else if (newValue === 'ABTestScheduleStrategy') {
-            self.strategyObs(scheduleUtils.newABTestStrategy());
-        } else if (newValue === 'CriteriaScheduleStrategy') {
-            self.strategyObs(scheduleUtils.newCriteriaStrategy());
-        }
+
+    self.schedulePlanTypeObs.subscribe(function(newType) {
+        var newStrategy = scheduleUtils.newStrategy(newType, self.strategyObs.callback());
+        self.strategyObs(newStrategy);
     });
 
     self.save = function(vm, event) {


### PR DESCRIPTION
Changes are coming that will make it impossible to clone a schedule plan in production while hiding it from existing users. Instead, you'll need to use a criteria schedule plan. So, you'll want to convert simple schedules into criteria schedules in order to version scheduling. So preserving the schedule information when you switch between plan types like this needs to work in the UI.
