### PR TITLE
Work to prevent submitting an external ID that already exists.

### DIFF
--- a/app/src/bindings.js
+++ b/app/src/bindings.js
@@ -132,12 +132,8 @@ ko.bindingHandlers.modal = {
             var $modal = $(".ui.modal");
             if ($modal.modal) {
                 if (newConfig.name !== "none") {
-                    $modal.modal({"closable": false, "detachable": false, "notify": 'always'});
-                    $modal.modal('show');
-                    // not sure how much this helps
-                    setTimeout(function() {
-                        $modal.modal("refresh"); 
-                    },100);
+                    $modal.modal({closable: false, detachable: false, notify: 'always', observeChanges: true});
+                    $modal.modal("show");
                 } else {
                     $modal.modal('hide');
                 }

--- a/app/src/dialogs/external_id_importer/external_id_importer.js
+++ b/app/src/dialogs/external_id_importer/external_id_importer.js
@@ -10,15 +10,6 @@ var SUBMISSION_SIZE = 5;
 var SUBMISSION_DELAY = 1200;
 var SPLIT_REGEX = /[,\s\t\r\n]+/;
 
-function createQueue(identifiers) {
-    var queue = [];
-    while (identifiers.length > SUBMISSION_SIZE) {
-        queue.push(identifiers.slice(0,SUBMISSION_SIZE));
-        identifiers = identifiers.slice(SUBMISSION_SIZE);
-    }
-    queue.push(identifiers);
-    return queue;    
-}
 function getPerc(step, max) {
     var perc = ((step/max)*100).toFixed(0);
     if (perc > 100) { perc = 100; }
@@ -86,16 +77,30 @@ module.exports = function(params) {
             return response;
         };
     }
-    function sequence(promise, array, func) {
-        return array.reduce(function(p, workItem) {
-            return p.then(function() {
-                if (cancel) { return; }
-                return func(workItem);
-            }).then(tickMeter).catch(tickMeterError).delay(SUBMISSION_DELAY); // delay. I love bluebird
-        }, promise);
-    }
     function initParticipantMaker(study) {
         self.createParticipant = createParticipantMaker(self.study.supportEmail);
+    }
+    function addIdentifier(promise, identifier, doCreateCredentials) {
+        promise = promise.then(function() {
+            if (cancel) { return; }
+            return serverService.addExternalIds([identifier])
+                .catch(tickMeterError);
+        });
+        if (doCreateCredentials) {
+            serverService.getParticipants(0, 5, "+"+identifier+"@").then(function(response) {
+                if (cancel) { return; }
+                if (response.items.length === 0) {
+                    return promise.then(function() {
+                        var participant = self.createParticipant(identifier);
+                        return serverService.createParticipant(participant)
+                            .catch(tickMeterError);
+                    });
+                } else {
+                    return Promise.resolve();
+                }
+            });
+        }
+        return promise.then(tickMeter, tickMeterError).delay(SUBMISSION_DELAY);
     }
  
     self.doImport = function(vm, event) {
@@ -107,22 +112,17 @@ module.exports = function(params) {
             return;
         }
         var doCreateCredentials = self.createCredentialsObs() || self.autoCredentialsObs();
-        
-        var queue = createQueue(identifiers);
-        // If the user checked the create credentials checkbox, or if the dialog was opened
-        // from a context where we always create the credentials in order to reduce confusion...
-        var participants = (doCreateCredentials) ? identifiers.map(self.createParticipant) : [];
 
         utils.startHandler(vm, event);
-        startProgressMeter(queue.length + participants.length);
-        
-        var promise = sequence(Promise.resolve(), queue, serverService.addExternalIds);
-        if (doCreateCredentials) {
-            promise = sequence(promise, participants, serverService.createParticipant);
+        startProgressMeter(identifiers.length+1);
+
+        var promise = Promise.resolve();
+        while(identifiers.length) {
+            promise = addIdentifier(promise, identifiers.shift(), doCreateCredentials);
         }
         promise.then(endProgressMeter(event.target))
             .then(utils.successHandler(vm, event))
-            .catch(utils.dialogFailureHandler(vm, event));
+            .catch(utils.dialogFailureHandler(vm, event));        
     };
 
     self.close = function(vm, event) {

--- a/app/src/dialogs/new_external_id/new_external_id.html
+++ b/app/src/dialogs/new_external_id/new_external_id.html
@@ -4,11 +4,11 @@
         New credentials from ID
     </div>
     <div class="content">
+        <errors></errors>
         <form id="newExternalId" class="ui form" action="" data-bind="submit: create">
-            <errors></errors>
             <div class="field">
                 <label>Identifier</label>
-                <input type="text" data-bind="textInput: identifierObs, hasFocus: true"/>
+                <input type="text" data-bind="textInput: identifierObs" autofocus/>
             </div>
         </form>
     </div>

--- a/app/src/pages/enrollees/enrollees.html
+++ b/app/src/pages/enrollees/enrollees.html
@@ -19,7 +19,6 @@
     <div class="ui empty secondary pointing menu"></div>
 </div>
 <div class="scrollbox">
-    <errors></errors>
     <div class="ui success icon message" style="margin-bottom: 1.4rem" data-bind="visible: showResultsObs">
         <i class="check sign icon"></i>
         <div class="content">

--- a/app/src/pages/enrollees/enrollees.js
+++ b/app/src/pages/enrollees/enrollees.js
@@ -41,9 +41,10 @@ module.exports = function() {
         var participant = utils.createParticipantForID(self.study.supportEmail, identifier);
         return serverService.createParticipant(participant);
     }
-    function updatePageWithResult() {
+    function updatePageWithResult(response) {
         self.showResultsObs(true);
         ko.postbox.publish('external-ids-page-refresh');
+        return response;
     }
     function convertToPaged(identifier) {
         return function() {

--- a/app/src/services/server_service.js
+++ b/app/src/services/server_service.js
@@ -128,8 +128,11 @@ function makeSessionWaitingPromise(httpAction, func) {
             // Soooo convert it to an error and copy over key aspects of the response. 
             p.fail(function(response) {
                 try {
-                    var error = new Error(response.responseJSON.message);
-                    error.responseJSON = response.responseJSON;
+                    var error = new Error();
+                    if (response.responseJSON) {
+                        error.message = response.responseJSON.message;
+                        error.responseJSON = response.responseJSON;
+                    }
                     error.statusText = response.statusText;
                     error.status = response.status;
                     reject(error);


### PR DESCRIPTION
When adding an ID we check first to see if it exists; when importing ids we now do them one at a time so we can check each one and see if it exists, skipping it if it does. The end result is that there should be no 409s from using these dialogs.

Small fix to dialog (there is a setting to reposition the dialog when the content changes, so using that rather than a refresh on a timer).
