### PR TITLE
Improvements to survey editor

### DIFF
--- a/app/css/panel.scss
+++ b/app/css/panel.scss
@@ -22,6 +22,7 @@
 .vs-item-content {
   width: 100%;
   padding: .5rem 1rem;
+  cursor: pointer;
 }
 .vs-item-delete {
   padding: .5rem 0;

--- a/app/css/survey.scss
+++ b/app/css/survey.scss
@@ -155,7 +155,7 @@
 .enum-list {
     padding:0!important;
     overflow-y: auto;
-    max-height: 253px;
+    max-height: 315px;
 }
     .enum-list-server-text {
         font-size: .8rem;

--- a/app/src/dialogs/enumeration_editor/enumeration_editor.html
+++ b/app/src/dialogs/enumeration_editor/enumeration_editor.html
@@ -3,7 +3,7 @@
     <div class="header">
         Enumerated Values
     </div>
-    <div class="content">
+    <div class="content" style="padding-top:.2rem">
         <div class="ui secondary pointing menu">
             <div class="item" data-bind="css:{active:isActive('editor')}, click: setTab('editor')">
                 Edit List
@@ -17,7 +17,7 @@
                 <div class="column enum-list" data-bind="foreach: listObs, dragula: {
                     elementSelector: '.vs-item', listObs: listObs}">
                     <div class="vs-item">
-                        <div class="vs-item-content">
+                        <div class="vs-item-content" data-bind="click: $component.moveToEditor">
                             <span data-bind="text: $data.label"></span>
                             <span data-bind="visible: $parent.hasDetail($data)">&mdash;<span data-bind="text: $data.detail"></span></span>
                             <div class="enum-list-server-text" data-bind="visible: $data.label !== $data.value, text: 'Value sent to server: '+$data.value"></div>
@@ -27,10 +27,10 @@
                 </div>
                 <div class="column">
                     <form class="ui form">
-                        <h4 class="ui dividing header">Add New List Item</h4>
+                        <h4 class="ui dividing header" data-bind="text: editorTitleObs"></h4>
                         <div class="field">
                             <input type="text" data-bind="textInput: labelObs, 
-                                event:{keydown: handleKeyEvent}" placeholder="Label"/>
+                                event:{keydown: handleKeyEvent}" placeholder="Label" autofocus/>
                         </div>
                         <div class="field">
                             <input type="text" data-bind="textInput: detailObs, 
@@ -41,7 +41,13 @@
                                 event:{keydown: handleKeyEvent}" placeholder="Server value (optional)"/>
                         </div>
                         <div class="field">
-                            <button class="ui small button" data-bind="click: addListItem">Add</button>
+                            <button class="ui small primary button" data-bind="click: addListItem, disable: newListItemValid,
+                                text: editorCommandObs">Add</button>
+                            <button class="ui small button" data-bind="click: cancelEditMode, visible: indexObs() !== null">Clear</button>
+                            <p class="help-text" style="margin-top:.5rem">The server value (or the label if there is none) can only contain 
+                                alphanumeric characters. It can also have spaces, dashes, 
+                                underscores and periods in the middle, but not more than one 
+                                at a time.</p>
                         </div>
                     </form>
                 </div>

--- a/app/src/dialogs/enumeration_editor/enumeration_editor.js
+++ b/app/src/dialogs/enumeration_editor/enumeration_editor.js
@@ -1,7 +1,44 @@
 var utils = require('../../utils');
 var ko = require('knockout');
-var hash = require('object-hash');
 var root = require('../../root');
+
+/**
+ * This is a simpler replacement for the object-hash library.
+ * File size: 53k less than including object-hash
+ * Performance: 2-3ms to calculate rather than 18-34ms
+ * Seems to be unique enough to differentate the lists, calling it good.
+ */
+function hash(array) {
+    if (array === null || array.length === 0) {
+        return 0;
+    }
+    var total = 0, i = array.length;
+    while(i--) {
+        var object = array[i];
+        var label = object.label;
+        var detail = object.detail;
+        var value = object.value; 
+        if (typeof label !== "undefined" && label !== null) {
+            total += checksum(label);
+        }
+        if (typeof detail !== "undefined" && detail !== null) {
+            total += checksum(detail);
+        }
+        if (typeof value !== "undefined" && value !== null) {
+            total += checksum(value);
+        }
+    }
+    return total;
+}
+
+function checksum(s) {
+    var chk = 0x12345678;
+    var i = s.length;
+    while(i--) {
+        chk += (s.charCodeAt(i) * (i + 1));
+    }
+    return (chk & 0xffffffff).toString(16);
+}
 
 function ListsSource(elements, element) {
     this.currentListEntry = null;
@@ -51,7 +88,7 @@ function makeListMapEntry(enumeration) {
     enumeration.forEach(function(item) {
         item.detail = item.detail || null;
     });
-    return {name: name, md5: hash.MD5(enumeration), enumeration: enumeration, occurrences: 1};
+    return {name: name, md5: hash(enumeration), enumeration: JSON.parse(JSON.stringify(enumeration)), occurrences: 1};
 }
 
 function itemLabel(item) {
@@ -72,6 +109,16 @@ function getEnumeration(element) {
     }
     return null;
 }
+function isValueValidOnServer(value) {
+    if (typeof value === "undefined" || value === null || value === "") {
+        return false;
+    }
+    if (value.length === 1) {
+        return /^[a-zA-Z0-9]+$/.test(value);
+    }
+    // alphanumerics with space/dash/underscore/period allowed in middle, but never in a sequence of two or more.
+    return /^[a-zA-Z0-9][a-zA-Z0-9-._\s]*[a-zA-Z0-9]$/.test(value) && !/[-._\s]{2,}/.test(value);
+}
 
 module.exports = function(params) {
     var self = this;
@@ -83,10 +130,12 @@ module.exports = function(params) {
     self.labelObs = ko.observable();
     self.detailObs = ko.observable();
     self.valueObs = ko.observable();
+    self.indexObs = ko.observable(null);
 
     // Should we copy edits over to all the same lists.
     self.copyToAllEnumsObs = ko.observable(true);
 
+    console.log("creating listsSource");
     var listsSource = new ListsSource(self.elementsObs(), self.element);
     self.allLists = ko.observableArray(listsSource.getAllLists());
 
@@ -110,16 +159,46 @@ module.exports = function(params) {
         }
         return true;
     };
+    self.moveToEditor = function(item, event) {
+        var index = self.listObs().indexOf(item);
+        self.indexObs(index);
+        self.labelObs(item.label);
+        self.detailObs(item.detail);
+        self.valueObs(item.value);
+    };
+    self.editorTitleObs = ko.computed(function() {
+        return (self.indexObs() !== null) ? 'Edit List Item' : 'Add New List Item';
+    });
+    self.editorCommandObs = ko.computed(function() {
+        return (self.indexObs() !== null) ? 'Update' : 'Add';
+    });
+    self.cancelEditMode = function() {
+        self.labelObs("");
+        self.detailObs("");
+        self.valueObs("");
+        self.indexObs(null);
+    };
     self.addListItem = function() {
         var label = self.labelObs();
         if (label) {
             var value = self.valueObs() || label;
-            self.listObs.push({label: label, value: value, detail: self.detailObs()});
+            if (self.indexObs() !== null) {
+                var item = self.listObs()[self.indexObs()];
+                item.label = self.labelObs();
+                item.value = value;
+                item.detail = self.detailObs();
+                self.listObs.splice(self.indexObs(),1);
+                self.listObs.splice(self.indexObs(),0,item);
+            } else {
+                self.listObs.push({label: label, value: value, detail: self.detailObs()});
+            }
         }
-        self.labelObs("");
-        self.detailObs("");
-        self.valueObs("");
+        self.cancelEditMode();
     };
+    self.newListItemValid = ko.computed(function() {
+        var value = self.valueObs() || self.labelObs();
+        return !isValueValidOnServer(value);
+    });
     self.saveList = function() {
         var entry = listsSource.getCurrentEntry();
 
@@ -139,9 +218,11 @@ module.exports = function(params) {
                 }
             });
         }
+        self.cancelEditMode();
         root.closeDialog();
     };
     self.cancel = function() {
+        self.cancelEditMode();
         root.closeDialog();
     };
 

--- a/app/src/dialogs/enumeration_editor/enumeration_editor.js
+++ b/app/src/dialogs/enumeration_editor/enumeration_editor.js
@@ -28,6 +28,7 @@ function hash(array) {
             total += checksum(value);
         }
     }
+    console.log(total);
     return total;
 }
 
@@ -213,7 +214,7 @@ module.exports = function(params) {
         if (self.copyToAllEnumsObs()) {
             self.elementsObs().forEach(function (element) {
                 var enumeration = getEnumeration(element);
-                if (enumeration && hash.MD5(enumeration) === oldMD5) {
+                if (enumeration && hash(enumeration) === oldMD5) {
                     copyEntry(element, entry);
                 }
             });

--- a/app/src/dialogs/event_id_editor/event_id_editor.html
+++ b/app/src/dialogs/event_id_editor/event_id_editor.html
@@ -45,7 +45,8 @@
                     </div>
                     <div style="margin-left: 2rem" class="grouped fields">
                         <div class="field">
-                            <select class="ui dropdown" data-bind="options: activityOptionsObs,
+                            <span data-bind="visible: !hasActivitiesObs()">There are no other schedules with activities you can schedule against.</span>
+                            <select class="ui dropdown" data-bind="visible: hasActivitiesObs, options: activityOptionsObs,
                                 optionsText: 'label', optionsValue: 'value', value: activityObs,
                                 optionsCaption: 'Select activity...', css:{disabled: !activityFinishedObs()}"></select>                                
                         </div>

--- a/app/src/dialogs/event_id_editor/event_id_editor.js
+++ b/app/src/dialogs/event_id_editor/event_id_editor.js
@@ -1,8 +1,8 @@
-var ko = require('knockout');
 var utils = require('../../utils');
 var optionsService = require('./../../services/options_service');
 var root = require('../../root');
 var UNARY_EVENTS = require('../../pages/schedule/schedule_utils').UNARY_EVENTS;
+var bind = require('../../binder');
 
 /**
  * This editor no longer allows you to edit survey or question triggered events, although these 
@@ -12,18 +12,18 @@ var UNARY_EVENTS = require('../../pages/schedule/schedule_utils').UNARY_EVENTS;
 module.exports = function(params) {
     var self = this;
 
+    bind(self)
+        .obs('enrollment', true)
+        .obs('enrollmentPeriod', Object.keys(UNARY_EVENTS)[0])
+        .obs('answer')
+        .obs('hasActivities', true)
+        .obs('activityFinished', false)
+        .obs('activity')
+        .obs('activityOptions[]');
+
     var originalValue = params.eventIdObs();
     self.clearEventIdFunc = params.clearEventIdFunc;
     self.eventIdObs = params.eventIdObs;
-    
-    self.enrollmentObs = ko.observable(true);
-    self.enrollmentPeriodObs = ko.observable(Object.keys(UNARY_EVENTS)[0]);
-    self.answerObs = ko.observable();
-
-    self.hasActivitiesObs = ko.observable(true);
-    self.activityFinishedObs = ko.observable(false);
-    self.activityObs = ko.observable();
-    self.activityOptionsObs = ko.observableArray([]);
     self.activityLabel = utils.makeOptionLabelFinder(self.activityOptionsObs);
 
     self.saveAndCloseDialog = function() {

--- a/app/src/dialogs/event_id_editor/event_id_editor.js
+++ b/app/src/dialogs/event_id_editor/event_id_editor.js
@@ -20,6 +20,7 @@ module.exports = function(params) {
     self.enrollmentPeriodObs = ko.observable(Object.keys(UNARY_EVENTS)[0]);
     self.answerObs = ko.observable();
 
+    self.hasActivitiesObs = ko.observable(true);
     self.activityFinishedObs = ko.observable(false);
     self.activityObs = ko.observable();
     self.activityOptionsObs = ko.observableArray([]);
@@ -27,7 +28,7 @@ module.exports = function(params) {
 
     self.saveAndCloseDialog = function() {
         var events = [];
-        if (self.activityFinishedObs()) {
+        if (self.activityFinishedObs() && self.activityObs()) {
             events.push("activity:" + self.activityObs() + ":finished");
         }
         if (self.enrollmentObs()) {
@@ -48,6 +49,9 @@ module.exports = function(params) {
         return optionsService.getActivityOptions();
     }
     function initEditor() {
+        if (self.activityOptionsObs().length === 0) {
+            self.hasActivitiesObs(false);
+        }
         if (self.eventIdObs()) {
             self.enrollmentObs(false);
             self.activityFinishedObs(false);

--- a/app/src/pages/survey/constraints/multi_constraints.html
+++ b/app/src/pages/survey/constraints/multi_constraints.html
@@ -37,3 +37,4 @@
         </td>
     </tr>
 </table>
+<div data-bind="attr:{class:$data.collectionName+'constraints_enumeration'}"></div>

--- a/app/src/pages/survey/constraints/multi_constraints.js
+++ b/app/src/pages/survey/constraints/multi_constraints.js
@@ -5,6 +5,7 @@ module.exports = function(params) {
     var self = this;
 
     surveyUtils.initConstraintsVM(self, params);
+    self.collectionName = params.collectionName;
     self.allowOtherObs = self.element.constraints.allowOtherObs;
     self.allowMultipleObs = self.element.constraints.allowMultipleObs;
     self.enumerationObs = self.element.constraints.enumerationObs;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.0",
     "node-sass": "^3.3.2",
-    "object-hash": "^0.8.0",
     "phantomjs-polyfill-object-assign": "0.0.2",
     "rewire": "^2.5.1",
     "rewire-webpack": "^1.0.1",


### PR DESCRIPTION
- errors about enumerations are now flagged in the editor under the appropriate constraints section.
- the enumerations editor now disables the add/edit button for an entry until it will produce a valid value, with explanatory text
- you can now edit an existing value in place through the clunky method of clicking and getting it in a variant of the editor to the side
- replaced object-hash library with a tailored hashing function that trims 53k off build and reduces 18-34ms initialization time to 2-3ms
