### PR TITLE
Allow multi-line text in survey prompt/prompt detail.

### DIFF
--- a/app/css/survey.scss
+++ b/app/css/survey.scss
@@ -177,6 +177,9 @@
     padding: .3rem;
     overflow: hidden;
 }
+[contenteditable] {
+    white-space: pre;
+}
 [contenteditable]:empty:before, [contenteditable] {
     content:attr(data-placeholder);
     -webkit-user-select: text!important;

--- a/app/src/bindings.js
+++ b/app/src/bindings.js
@@ -153,14 +153,9 @@ ko.bindingHandlers.modal = {
 ko.bindingHandlers.editableDiv = {
     init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
         var observer = valueAccessor();
-        element.textContent = observer() || '';
-        element.addEventListener('keydown', function(e) {
-            if (e.keyCode === 13){
-                e.preventDefault();
-            }
-        }, false);
+        element.innerText = observer() || '';
         element.addEventListener('keyup', function() {
-            observer(element.textContent);
+            observer(element.innerText);
         }, false);
     }
 };


### PR DESCRIPTION
 I used to disallow this because of the issues it causes, but Shannon is now creating surveys that are looking for carriage returns.