### PR TITLE
Restoring duration controls in the schedule

### DIFF
--- a/app/css/forms.scss
+++ b/app/css/forms.scss
@@ -3,7 +3,6 @@
     content: '*';
     color: #d95c5c;
 }
-/*
 .duration-control {
     @include flex-box(row);
 }
@@ -14,7 +13,6 @@
         margin-left: .5rem;
         width: 6rem!important;
     }
-*/
 /* This is a magic number that aligns text with Semantic UI controls. */
 /* As such I have a special class for it. */
 .inline-form-text {


### PR DESCRIPTION
This CSS is for the schedule component, not the survey editor.