### PR TITLE
Fixing survey editor to delete GUIDs when an element is copied

### DIFF
--- a/app/src/pages/survey/survey.js
+++ b/app/src/pages/survey/survey.js
@@ -94,13 +94,14 @@ module.exports = function(params) {
         surveyUtils.observablesToElement(element);
 
         var newElement = JSON.parse(JSON.stringify(element));
+        delete newElement.guid;
+        delete newElement.identifier;
         if (newElement.type === "SurveyInfoScreen") {
             newElement.title = "[Copy] " + newElement.title;
         } else {
             newElement.prompt = "[Copy] " + newElement.prompt;
         }
         newElement.identifier = fn.incrementNumber(newElement.identifier);
-        
         surveyUtils.elementToObservables(newElement);
         self.elementsObs.splice(index+1, 0, newElement);
         scrollTo(index+1);

--- a/app/src/pages/survey/survey_versions.html
+++ b/app/src/pages/survey/survey_versions.html
@@ -30,7 +30,7 @@
         <tbody data-bind="foreach: itemsObs">
             <tr data-bind="css: { positive: $data.published }">
                 <td>
-                    <a data-bind="href: '#/surveys/'+$data.guid+'/'+$data.createdOn, text: $data.name"></span></a>
+                    <a data-bind="href: '#/surveys/'+$data.guid+'/'+$data.createdOn+'/editor', text: $data.name"></span></a>
                 </td>
                 <td data-bind="text:$parent.formatDateTime($data.createdOn)"></td>
                 <td>


### PR DESCRIPTION
Also fixing a link that was broken under the history tab to load older versions.