### PR TITLE
Fixing the formatting of clientData on the schedules pages

### DIFF
--- a/app/src/json_formatter.js
+++ b/app/src/json_formatter.js
@@ -58,7 +58,7 @@ function mapClientDataItem(item) {
     item.collapsedObs = ko.observable(true);
     item.isDisabled = (item.status === 'expired');
     if (item.clientData) {
-        item.formattedData = prettyPrintHTML(item.clientData);
+        item.formattedData = prettyPrintHTML(JSON.parse(item.clientData));
     }
     return item;
 }

--- a/app/src/pages/participant/general.html
+++ b/app/src/pages/participant/general.html
@@ -54,7 +54,7 @@
         </div>
         
         <div class="equal width fields">
-            <div class="required field" id="email">
+            <div class="field" id="email">
                 <label>Email</label>
                 <input type="text" data-bind="visible: emailNullObs, textInput: emailObs"/>
                 <a class="input-field-padding" data-bind="visible: !emailNullObs(), href: emailLink, text: emailObs"></a>


### PR DESCRIPTION
The JSON is actually being sent to the server as a string by the Android app, which makes the formatting of the JSON in the UI pretty useless. So we play some games with double-parsing to get to a state where it's represented as literal JSON, then we can format it.