### PR TITLE
Fixing "resend consent" feature, cleaning up hierarchy of subpopulation pages

### DIFF
--- a/app/src/pages/participant/consents.html
+++ b/app/src/pages/participant/consents.html
@@ -58,8 +58,8 @@
                     <span class="red" data-bind="text: $data.withdrewOn"></span>
                 </td>
                 <td>
-                    <button data-bind="visible: $data.name !== 'No consent' && $data.withdrewOn > 0, 
-                        click: $component.resendConsent" class="ui basic compact mini button">Resend consent</button>
+                    <button data-bind="visible: $data.eligibleToWithdraw, click: $component.resendConsent" 
+                        class="ui basic compact mini button">Resend consent</button>
                 </td>
                 <td>
                     <a target="_blank" rel="noopener" data-bind="visible: $data.name !== 'No consent', 

--- a/app/src/pages/participant/consents.js
+++ b/app/src/pages/participant/consents.js
@@ -40,7 +40,6 @@ module.exports = function(params) {
     }).catch(failureHandler);
 
     self.resendConsent = function(vm, event) {
-        console.log(vm);
         let subpopGuid = vm.consentURL.split("/subpopulations/")[1].split("/consents/")[0];
         alerts.confirmation("This will send email to this user.\n\nDo you wish to continue?", function() {
             utils.startHandler(vm, event);

--- a/app/src/pages/participant/consents.js
+++ b/app/src/pages/participant/consents.js
@@ -40,6 +40,7 @@ module.exports = function(params) {
     }).catch(failureHandler);
 
     self.resendConsent = function(vm, event) {
+        console.log(vm);
         let subpopGuid = vm.consentURL.split("/subpopulations/")[1].split("/consents/")[0];
         alerts.confirmation("This will send email to this user.\n\nDo you wish to continue?", function() {
             utils.startHandler(vm, event);

--- a/app/src/pages/subpopulation/download.html
+++ b/app/src/pages/subpopulation/download.html
@@ -9,8 +9,7 @@
         </div>
         <div class="fixed-header-buttons"></div>
     </div>
-    <subpop-tabset params="guidObs: guidObs, createdOnObs: createdOnObs, 
-        publishedConsentCreatedOnObs: publishedConsentCreatedOnObs"></subpop-tabset>
+    <subpop-tabset params="guidObs: guidObs"></subpop-tabset>
 </div>
 <div class="scrollbox">
     <div class="ui grid">
@@ -40,8 +39,7 @@
         </div>
         <div class="six wide column">
             <div class="ui message">
-                <p>The published version of the consent can be accessed from your mobile app, or from other support materials,
-                    at the following addresses. </p>
+                <p>The published version of the consent can be accessed from your mobile app, or from other support materials, at the following addresses. </p>
             </div>
         </div>
     </div>

--- a/app/src/pages/subpopulation/download.js
+++ b/app/src/pages/subpopulation/download.js
@@ -15,8 +15,6 @@ module.exports = function(params) {
     new Binder(self)
         .obs('name')
         .obs('guid', params.guid)
-        .obs('createdOn', params.createdOn)
-        .obs('publishedConsentCreatedOn')
         .obs('htmlUrl')
         .obs('pdfUrl');
     
@@ -30,7 +28,6 @@ module.exports = function(params) {
 
     serverService.getSubpopulation(params.guid)
         .then(fn.handleObsUpdate(self.nameObs, 'name'))
-        .then(fn.handleObsUpdate(self.publishedConsentCreatedOnObs, 'publishedConsentCreatedOn'))
         .then(serverService.getSession.bind(serverService))
         .then(updateURLs)
         .catch(failureHandler);    

--- a/app/src/pages/subpopulation/editor.html
+++ b/app/src/pages/subpopulation/editor.html
@@ -12,10 +12,26 @@
             <button class="ui tiny primary button" data-bind="click: save">Save</button>
         </div>
     </div>
-    <subpop-tabset params="guidObs: guidObs, createdOnObs: createdOnObs, 
-        publishedConsentCreatedOnObs: publishedConsentCreatedOnObs"></subpop-tabset>
+    <subpop-tabset params="guidObs: guidObs"></subpop-tabset>
 </div>
 <div class="scrollbox">
+    <div class="line-control" style="margin-bottom: 1rem">
+        <div class="line-control-stretch">
+            <p>View the <a data-bind="href: createHistoryLink"> 
+                <i style="margin-right:0" class="history icon"></i>Edit History</a> of this document.</p>
+        </div>
+        <div class="line-control">
+            <div data-bind="visible: !!createdOnObs()" style="margin-right: 1rem">
+                <i class="clock icon"></i> <span data-bind="text: formatDateTime(createdOnObs())"></span>
+            </div>
+            <div class="green mini ui label" data-bind="visible: activeObs">
+                <i class="checkmark icon"></i> Published
+            </div>
+            <div class="orange ui mini label" data-bind="visible: !activeObs()">
+                <i class="warning icon"></i> Not Published
+            </div>
+        </div>
+    </div>
     <textarea id="consentEditor" data-bind="ckeditor: initEditor" class="ui textarea"></textarea>
 </div>
 

--- a/app/src/pages/subpopulation/editor.js
+++ b/app/src/pages/subpopulation/editor.js
@@ -27,7 +27,6 @@ module.exports = function(params) {
         return self.createdOnObs() === 'recent' || self.createdOnObs() === self.publishedConsentCreatedOnObs();
     });
     self.createHistoryLink = ko.computed(function() {
-        //return '#/subpopulations/' + self.guidObs() + '/history/' + self.createdOnObs();
         return '#/subpopulations/' + self.guidObs() + '/editor/' + self.createdOnObs() + "/history";
     });
 

--- a/app/src/pages/subpopulation/general.html
+++ b/app/src/pages/subpopulation/general.html
@@ -11,8 +11,7 @@
             <button class="ui tiny primary button" data-bind="click: save">Save</button>
         </div>
     </div>
-    <subpop-tabset params="isNewObs: isNewObs, guidObs: guidObs, createdOnObs: createdOnObs, 
-        publishedConsentCreatedOnObs: publishedConsentCreatedOnObs"></subpop-tabset>
+    <subpop-tabset params="isNewObs: isNewObs, guidObs: guidObs"></subpop-tabset>
 </div>
 <div class="scrollbox">
     <errors></errors>
@@ -27,8 +26,10 @@
                 <input type="text" data-bind="textInput: descriptionObs"/>
             </div>
         </div>
+
         <h4 style="margin-top:0">Assignment based on</h4>
-        <!-- ko component: {name:"criteria", params:{id:"", criteriaObs:criteriaObs}} --><!-- /ko -->
+        <criteria params="id: '', criteriaObs: criteriaObs"></criteria>
+        
         <div class="fields">
             <div class="six wide field">
                 <div class="field">

--- a/app/src/pages/subpopulation/general.js
+++ b/app/src/pages/subpopulation/general.js
@@ -15,16 +15,13 @@ function newSubpop() {
 }
 
 module.exports = function(params) {
-    console.log("GENERAL", JSON.stringify(params));
     let self = this;
 
     let binder = new Binder(self)
         .obs('isNew', params.guid === "new")
         .obs('guid', params.guid)
-        .obs('createdOn', params.createdOn)
         .obs('title', 'New Consent Group')
         .bind('name')
-        .bind('publishedConsentCreatedOn')
         .bind('description')
         .bind('required', true)
         .bind('criteria');
@@ -51,13 +48,6 @@ module.exports = function(params) {
             .catch(failureHandler);
     };
     
-    function updateTimestamp(subpop) {
-        if (!params.createdOn) {
-            self.createdOnObs(subpop.publishedConsentCreatedOn);
-        }
-        return subpop;
-    }
-
     serverService.getStudy()
         .then(binder.assign('study'))
         .then(function(study) {
@@ -69,8 +59,6 @@ module.exports = function(params) {
                 return serverService.getSubpopulation(params.guid)
                     .then(binder.assign('subpopulation'))
                     .then(binder.update())
-                    .then(updateTimestamp)
-                    .then(fn.log('subpop'))
                     .then(titleUpdated);
             }
         }).catch(failureHandler);

--- a/app/src/pages/subpopulation/history.html
+++ b/app/src/pages/subpopulation/history.html
@@ -9,10 +9,30 @@
         </div>
         <div class="fixed-header-buttons"></div>
     </div>
-    <subpop-tabset params="guidObs: guidObs, createdOnObs: createdOnObs, 
-        publishedConsentCreatedOnObs: publishedConsentCreatedOnObs"></subpop-tabset>
+    <subpop-tabset params="guidObs: guidObs"></subpop-tabset>
 </div>
 <div class="scrollbox">
+    <div class="line-control" style="margin-bottom: 1rem">
+        <div class="line-control-stretch">
+            <div class="ui breadcrumb">
+                <a class="section" 
+                    data-bind="href:'#/subpopulations/'+guidObs()+'/editor/'+createdOnObs()">Consent Editor</a>
+                <i class="right chevron icon divider"></i>
+                Edit History
+            </div>
+        </div>
+        <div class="line-control">
+            <div data-bind="visible: !!createdOnObs()" style="margin-right: 1rem">
+                <i class="clock icon"></i> <span data-bind="text: formatDateTime(createdOnObs())"></span>
+            </div>
+            <div class="green mini ui label" data-bind="visible: activeObs">
+                <i class="checkmark icon"></i> Published
+            </div>
+            <div class="orange ui mini label" data-bind="visible: !activeObs()">
+                <i class="warning icon"></i> Not Published
+            </div>
+        </div>
+    </div>
     <div class="ui grid">
         <div class="ten wide column">
             <table class="ui compact selectable table">
@@ -26,7 +46,7 @@
                     <tr data-bind="css: { positive: $data.active }">
                         <td>
                             <a data-bind="attr: {href: '#/subpopulations/'+$parent.guidObs()+
-                                '/consents/'+$data.createdOn}, text: $parent.formatDateTime($data.createdOn)"></a>
+                                '/editor/'+$data.createdOn}, text: $parent.formatDateTime($data.createdOn)"></a>
                         </td>
                         <td>
                             <div data-bind="visible: $data.active" style="text-align: right">

--- a/app/src/pages/subpopulation/tabset.html
+++ b/app/src/pages/subpopulation/tabset.html
@@ -3,28 +3,10 @@
         <i class="setting icon"></i> General
     </a>
     <a data-bind="tabber, href: linkMaker('editor')">
-        <i class="file outline icon"></i> Editor
-    </a>
-    <a data-bind="tabber, href: linkMaker('history')">
-        <i class="history icon"></i> History &amp; Publication
+        <i class="file outline icon"></i> Consent Editor
     </a>
     <a data-bind="tabber, href: linkMaker('download')">
         <i class="download icon"></i> Download
     </a>
-    <div class="right menu pub-status">
-        <div class="item" data-bind="visible: !!createdOnObs()">
-            <i class="clock icon"></i> <span data-bind="text: formatDateTime(createdOnObs())"></span>
-        </div>
-        <div class="item" data-bind="visible: activeObs">
-            <div class="green mini ui label">
-                <i class="checkmark icon"></i> Published
-            </div>
-        </div>
-        <div class="item" data-bind="visible: !activeObs()">
-            <div class="orange ui mini label">
-                <i class="warning icon"></i> Not Published
-            </div>
-        </div>
-    </div>    
 </div>
 <div class="ui empty secondary pointing menu" data-bind="visible: isNewObs"></div>

--- a/app/src/pages/subpopulation/tabset.js
+++ b/app/src/pages/subpopulation/tabset.js
@@ -4,25 +4,18 @@ import ko from 'knockout';
 module.exports = function(params) {
     let self = this;
 
-    fn.copyProps(self, params, 'guidObs', 'createdOnObs', 'publishedConsentCreatedOnObs', 'isNewObs');
+    fn.copyProps(self, params, 'guidObs', 'isNewObs');
     fn.copyProps(self, fn, 'formatDateTime');
 
     // Only passed in on the on the general tab
     if (!self.isNewObs) {
         self.isNewObs = ko.observable(false);
     }
-    self.activeObs = ko.computed(function() {
-        return self.createdOnObs() === self.publishedConsentCreatedOnObs();
-    });
 
     self.computeds = [];
     self.linkMaker = function(tabName) {
         let c = ko.computed(function() {
-            var timestamp = self.createdOnObs();
-            if (!timestamp) {
-                timestamp = 'recent';
-            }
-            return '#/subpopulations/' + self.guidObs() + '/consents/' + timestamp + '/' + tabName;
+            return '#/subpopulations/' + self.guidObs() + '/' + tabName;
         });
         self.computeds.push(c);
         return c;

--- a/app/src/routes.js
+++ b/app/src/routes.js
@@ -86,17 +86,21 @@ router.on('/sms_templates/account_exists', routeTo('sms_account_exists', 'sms'))
 router.on('/sms_templates/phone_signin', routeTo('sms_phone_signin', 'sms'));
 router.on('/sms_templates/app_install_link', routeTo('sms_app_install_link', 'sms'));
 
-router.on('/subpopulations/:guid/consents/recent/general', routeTo('subpopulation', 'subpops', GUID));
-router.on('/subpopulations/:guid/consents/:createdOn/general', routeTo('subpopulation', 'subpops', GUID_CREATEDON));
-router.on('/subpopulations/:guid/consents/:createdOn/editor', 
-    routeTo('subpopulation_editor', 'subpops', GUID_CREATEDON));
-router.on('/subpopulations/:guid/consents/:createdOn/history', 
-    routeTo('subpopulation_history', 'subpops', GUID_CREATEDON));
-router.on('/subpopulations/:guid/consents/:createdOn/download', 
-    routeTo('subpopulation_download', 'subpops', GUID_CREATEDON));
-router.on('/subpopulations/:guid', redirectTo('/subpopulations/{0}/consents/recent/general'));
-router.on('/subpopulations/:guid/consents/:createdOn', redirectTo('/subpopulations/{0}/consents/{1}/editor'));
 router.on('/subpopulations', routeTo('subpopulations', 'subpops'));
+router.on('/subpopulations/:guid', redirectTo('/subpopulations/{0}/general'));
+router.on('/subpopulations/:guid/general', routeTo('subpopulation', 'subpops', GUID));
+router.on('/subpopulations/:guid/editor', redirectTo('/subpopulations/{0}/editor/recent'));
+router.on('/subpopulations/:guid/editor/recent', routeTo('subpopulation_editor', 'subpops', GUID));
+router.on('/subpopulations/:guid/editor/:createdOn', routeTo('subpopulation_editor', 'subpops', GUID_CREATEDON));
+
+router.on('/subpopulations/:guid/editor/recent/history', routeTo('subpopulation_history', 'subpops', GUID));
+router.on('/subpopulations/:guid/editor/:createdOn/history', routeTo('subpopulation_history', 'subpops', GUID_CREATEDON));
+
+/*
+router.on('/subpopulations/:guid/history/recent', routeTo('subpopulation_history', 'subpops', GUID));
+router.on('/subpopulations/:guid/history/:createdOn', routeTo('subpopulation_history', 'subpops', GUID_CREATEDON));
+*/
+router.on('/subpopulations/:guid/download', routeTo('subpopulation_download', 'subpops', GUID));
 
 router.on('/reports', redirectTo('/reports/uploads'));
 router.on('/reports/uploads', routeTo('dailyUploads', 'reports'));

--- a/app/src/routes.js
+++ b/app/src/routes.js
@@ -92,14 +92,8 @@ router.on('/subpopulations/:guid/general', routeTo('subpopulation', 'subpops', G
 router.on('/subpopulations/:guid/editor', redirectTo('/subpopulations/{0}/editor/recent'));
 router.on('/subpopulations/:guid/editor/recent', routeTo('subpopulation_editor', 'subpops', GUID));
 router.on('/subpopulations/:guid/editor/:createdOn', routeTo('subpopulation_editor', 'subpops', GUID_CREATEDON));
-
 router.on('/subpopulations/:guid/editor/recent/history', routeTo('subpopulation_history', 'subpops', GUID));
 router.on('/subpopulations/:guid/editor/:createdOn/history', routeTo('subpopulation_history', 'subpops', GUID_CREATEDON));
-
-/*
-router.on('/subpopulations/:guid/history/recent', routeTo('subpopulation_history', 'subpops', GUID));
-router.on('/subpopulations/:guid/history/:createdOn', routeTo('subpopulation_history', 'subpops', GUID_CREATEDON));
-*/
 router.on('/subpopulations/:guid/download', routeTo('subpopulation_download', 'subpops', GUID));
 
 router.on('/reports', redirectTo('/reports/uploads'));


### PR DESCRIPTION
This has long annoyed me... it's now more accurate.