### PR TITLE
Remove an intermediate level of caching that can't deal with the interaction of some newly created objects.

### DIFF
--- a/app/src/pages/appconfig/appconfig.js
+++ b/app/src/pages/appconfig/appconfig.js
@@ -136,6 +136,7 @@ module.exports = function(params) {
             .then(updateModifiedOn)
             .then(fn.returning(self.appConfig))
             .then(titleUpdated)
+            //.then(sharedModuleUtils.loadNameMaps)
             .then(utils.successHandler(vm, event, "App configuration has been saved."))
             .catch(failureHandler);
     };

--- a/app/src/shared_module_utils.js
+++ b/app/src/shared_module_utils.js
@@ -5,7 +5,6 @@ const sharedModuleHTMLMap = {};
 const surveyNameMap = {};
 const schemaNameMap = {};
 const objImported = {};
-let allLoaded = false;
 
 function updateSharedModuleNameMap(response) {
     response.items.forEach(function(metadata) {
@@ -25,19 +24,14 @@ function updateSchemaNameMap(response) {
     response.items.forEach(function(schema) {
         schemaNameMap[schema.schemaId] = schema.name;
     });
-    allLoaded = true;
 }
 function loadNameMaps() {
-    if (allLoaded) {
-        return Promise.resolve();
-    } else {
-        return serverService.getMetadata({mostrecent:true, published:true})
-            .then(updateSharedModuleNameMap)
-            .then(serverService.getSurveys.bind(serverService))
-            .then(updateSurveyNameMap)
-            .then(serverService.getAllUploadSchemas.bind(serverService))
-            .then(updateSchemaNameMap);
-    }
+    return serverService.getMetadata({mostrecent:true, published:true})
+        .then(updateSharedModuleNameMap)
+        .then(serverService.getSurveys.bind(serverService))
+        .then(updateSurveyNameMap)
+        .then(serverService.getAllUploadSchemas.bind(serverService))
+        .then(updateSchemaNameMap);
 }
 function formatDescription(metadata, withVersion) {
     let array = [];


### PR DESCRIPTION
We are caching at the primitive level of REST calls so this isn't going to be a large performance hit. We're just recalculating the JavaScript object structure.