### PR TITLE
Changing how we lock the BSM to a specific study

### DIFF
--- a/app/src/dialogs/sign_in/sign_in.js
+++ b/app/src/dialogs/sign_in/sign_in.js
@@ -46,12 +46,12 @@ function makeReloader(studyKey, environment) {
 module.exports = function() {
     let self = this;
 
-    let isLocked = fn.isNotBlank(root.queryParams.study);
+    let isLocked = fn.isNotBlank(root.queryParams.studyPath);
     const SYNTH_EVENT = {target: document.querySelector("#submitButton")};
 
     let studyKey, env;    
     if (isLocked) {
-        studyKey = root.queryParams.study;
+        studyKey = root.queryParams.studyPath;
         env = 'production';
     } else {
         studyKey = storeService.get(STUDY_KEY) || 'api';

--- a/app/src/root.js
+++ b/app/src/root.js
@@ -124,7 +124,7 @@ let RootViewModel = function() {
 
 let root = new RootViewModel();
 
-root.queryParams = {};
+root.queryParams = {studyPath: document.location.pathname.substring(1)};
 if (document.location.search) {
     document.location.search.substring(1).split("&").forEach(function(pair) {
         let fragments = pair.split("=");


### PR DESCRIPTION
Instead of query parameter:
https://research.sagebridge.org/?study=foo#/reports/uploads

Use a path:
https://research.sagebridge.org/foo#/reports/uploads

It's easier to send to people.